### PR TITLE
OX Multi-queue timeout support + safe memory replacement

### DIFF
--- a/hw/block/ox-ctrl/core.c
+++ b/hw/block/ox-ctrl/core.c
@@ -49,6 +49,7 @@
 #include <argp.h>
 #include <time.h>
 #include "hw/block/ox-ctrl/include/ssd.h"
+#include "hw/block/ox-ctrl/include/ox-mq.h"
 #include "hw/block/ox-ctrl/include/uatomic.h"
 #include "hw/pci/pci.h"
 
@@ -106,93 +107,77 @@ static struct nvm_ftl *nvm_get_ftl_instance(uint16_t ftl_id)
     return NULL;
 }
 
-static uint8_t nvm_ftl_q_schedule (struct nvm_ftl *ftl) {
-    uint8_t q;
-    pthread_mutex_lock(&ftl->q_mutex);
-    q = ftl->last_q = (ftl->last_q + 1 >= ftl->nq) ? 0 : ftl->last_q + 1;
-    pthread_mutex_unlock(&ftl->q_mutex);
-    return q;
+static uint16_t nvm_ftl_q_schedule (struct nvm_ftl *ftl, struct nvm_io_cmd *cmd)
+{
+    return cmd->channel->ch_id % ftl->nq;
 }
 
-static void *nvm_ftl_io_thread (void *arg)
+static void nvm_complete_to_host (struct nvm_io_cmd *cmd)
 {
-    struct nvm_ftl *ftl = (struct nvm_ftl *) arg;
-    struct nvm_io_cmd *cmd;
-    uint64_t *cmd_addr;
-    int ret, q_id;
+    NvmeRequest *req = (NvmeRequest *) cmd->req;
 
-    q_id = nvm_ftl_q_schedule (ftl);
+    req->status = (cmd->status.status == NVM_IO_SUCCESS) ?
+                NVME_SUCCESS : (cmd->status.nvme_status) ?
+                      cmd->status.nvme_status : NVME_INTERNAL_DEV_ERROR;
+
+    if (core.debug)
+        printf(" [NVMe cmd 0x%x. cid: %d completed. Status: %x]\n",
+                                 req->cmd->opcode, req->cmd->cid, req->status);
+
+    ((core.run_flag & RUN_TESTS) && core.tests_init->complete_io) ?
+        core.tests_init->complete_io(req) : nvme_rw_cb(req);
+}
+
+void nvm_complete_ftl (struct nvm_io_cmd *cmd)
+{
+    int retry, ret;
+    struct ox_mq_entry *req = (struct ox_mq_entry *) cmd->mq_req;
+
+    retry = NVM_QUEUE_RETRY;
     do {
-        cmd = 0;
-        ret = mq_receive (ftl->mq_id[q_id], (char *)&cmd_addr,
-                                                      sizeof (uint64_t), NULL);
-        if (ret != NVM_FTL_MQ_MSGSIZE)
-            continue;
-
-        cmd = (struct nvm_io_cmd *) cmd_addr;
-	if(cmd == NULL)
-            continue;
-
-        ret = ftl->ops->submit_io(cmd);
-
+        ret = ox_mq_complete_req(cmd->channel->ftl->mq, req);
         if (ret) {
-            log_err ("[ERROR: Cmd %x not completed. Aborted.]\n", cmd->cmdtype);
-            nvm_complete_io(cmd);
+            retry--;
+            usleep (NVM_QUEUE_RETRY_SLEEP);
         }
-
-    } while (ftl->active);
-
-    log_info("  [ftl: IO thread (%s)(%d) killed.]\n", ftl->name, q_id);
-
-    return NULL;
+    } while (ret && retry);
 }
 
-static int nvm_create_ftl_queue (struct nvm_ftl *ftl, uint8_t index)
+static void nvm_ftl_process_sq (struct ox_mq_entry *req)
 {
-    char *mqname = (char *) malloc(strlen(NVM_FTL_MQ)+4);
-    char *mqnb = (char *) malloc(3);
-    if (!mqname || !mqnb)
-        return EMEM;
+    struct nvm_io_cmd *cmd = (struct nvm_io_cmd *) req->opaque;
+    struct nvm_ftl *ftl = cmd->channel->ftl;
+    int ret;
 
-    memcpy(mqname, NVM_FTL_MQ, strlen(NVM_FTL_MQ));
-    mqname[strlen(NVM_FTL_MQ)] = '\0';
-    sprintf(mqnb,"%d",core.ftl_q_count);
-    strcat(mqname, mqnb);
-    mq_unlink (mqname);
-    struct mq_attr mqAttr = {0, NVM_FTL_MQ_MAXMSG, NVM_FTL_MQ_MSGSIZE, 0};
-    ftl->mq_id[index] = mq_open (mqname, O_RDWR|O_CREAT,
-                                                     S_IWUSR|S_IRUSR, &mqAttr);
-    if (ftl->mq_id[index] < 0)
-	return EFTL_REGISTER;
+    cmd->mq_req = (void *) req;
+    ret = ftl->ops->submit_io(cmd);
 
-    if(pthread_create(&ftl->io_thread[index], NULL, nvm_ftl_io_thread,
-                                                                 (void *) ftl))
-        return EFTL_REGISTER;
+    if (ret) {
+        log_err ("[ERROR: Cmd %x not completed. Aborted.]\n", cmd->cmdtype);
+        nvm_complete_ftl(cmd);
+    }
+}
 
-    log_info("  [nvm: FTL Queue (%s) started.]\n", mqname);
+static void nvm_ftl_process_cq (void *opaque)
+{
+    struct nvm_io_cmd *cmd = (struct nvm_io_cmd *) opaque;
 
-    core.ftl_q_count++;
-    free(mqname);
-    free(mqnb);
-
-    return 0;
+    nvm_complete_to_host (cmd);
 }
 
 int nvm_register_ftl (struct nvm_ftl *ftl)
 {
-    int i, ret;
-
     if (strlen(ftl->name) > MAX_NAME_SIZE)
         return EMAX_NAME_SIZE;
 
-    pthread_mutex_init (&ftl->q_mutex, NULL);
     ftl->active = 1;
-    ftl->last_q = ftl->nq - 1;
 
-    for (i = 0; i < ftl->nq; i++) {
-        ret = nvm_create_ftl_queue (ftl, i);
-        if (ret) return ret;
-    }
+    ftl->mq = ox_mq_init(ftl->nq, NVM_FTL_QUEUE_SIZE, nvm_ftl_process_sq,
+                                                           nvm_ftl_process_cq);
+    if (!ftl->mq)
+        return -1;
+
+    core.ftl_q_count += ftl->nq;
 
     LIST_INSERT_HEAD(&ftl_head, ftl, entry);
     core.ftl_count++;
@@ -210,7 +195,6 @@ int nvm_register_ftl (struct nvm_ftl *ftl)
     if (ftl->bbtbl_format == FTL_BBTBL_BYTE)
         log_info("    [%s Bad block table type: Byte array. 1 byte per blk.]\n",
                                                                     ftl->name);
-
     return 0;
 }
 
@@ -247,68 +231,51 @@ void nvm_callback (struct nvm_mmgr_io_cmd *cmd)
     }
 }
 
-void nvm_complete_io (struct nvm_io_cmd *cmd)
-{
-    NvmeRequest *req = (NvmeRequest *) cmd->req;
-
-    req->status = (cmd->status.status == NVM_IO_SUCCESS) ?
-                NVME_SUCCESS : (cmd->status.nvme_status) ?
-                      cmd->status.nvme_status : NVME_INTERNAL_DEV_ERROR;
-
-    if (core.debug)
-        printf(" [NVMe cmd 0x%x. cid: %d completed. Status: %x]\n",
-                                 req->cmd->opcode, req->cmd->cid, req->status);
-
-    ((core.run_flag & RUN_TESTS) && core.tests_init->complete_io) ?
-        core.tests_init->complete_io(req) : nvme_rw_cb(req);
-}
-
-int nvm_submit_io (struct nvm_io_cmd *io)
+int nvm_submit_ftl (struct nvm_io_cmd *cmd)
 {
     struct nvm_channel *ch;
     int ret, retry, i, qid;
-    uint64_t cmd_addr = 0;
-    NvmeRequest *req = (NvmeRequest *) io->req;
+    NvmeRequest *req = (NvmeRequest *) cmd->req;
     uint8_t aux_ch;
 
-    io->status.nvme_status = NVME_SUCCESS;
+    cmd->status.nvme_status = NVME_SUCCESS;
 
-    switch (io->status.status) {
+    switch (cmd->status.status) {
         case NVM_IO_NEW:
             break;
         case NVM_IO_PROCESS:
             break;
         case NVM_IO_FAIL:
             req->status = NVME_DATA_TRAS_ERROR;
-            nvm_complete_io(io);
+            nvm_complete_to_host(cmd);
             return NVME_DATA_TRAS_ERROR;
         case NVM_IO_SUCCESS:
             req->status = NVME_SUCCESS;
-            nvm_complete_io(io);
+            nvm_complete_to_host(cmd);
             return NVME_SUCCESS;
         default:
             req->status = NVME_INTERNAL_DEV_ERROR;
-            nvm_complete_io(io);
+            nvm_complete_to_host(cmd);
             return NVME_INTERNAL_DEV_ERROR;
     }
 
 #if LIGHTNVM
     /* For now, the host ppa channel must be aligned with core.nvm_ch[] */
     /* All ppas within the vector must address to the same channel */
-    aux_ch = io->ppalist[0].g.ch;
+    aux_ch = cmd->ppalist[0].g.ch;
 
     if (aux_ch >= core.nvm_ch_count) {
         syslog(LOG_INFO,"[nvm ERROR: IO failed, channel not found.]\n");
         req->status = NVME_INTERNAL_DEV_ERROR;
-        nvm_complete_io(io);
+        nvm_complete_to_host(cmd);
         return NVME_INTERNAL_DEV_ERROR;
     }
 
-    for (i = 1; i < io->n_sec; i++) {
-        if (io->ppalist[i].g.ch != aux_ch) {
+    for (i = 1; i < cmd->n_sec; i++) {
+        if (cmd->ppalist[i].g.ch != aux_ch) {
             syslog(LOG_INFO,"[nvm ERROR: IO failed, ch does not match.]\n");
             req->status = NVME_INVALID_FIELD;
-            nvm_complete_io(io);
+            nvm_complete_to_host(cmd);
             return NVME_INVALID_FIELD;
         }
     }
@@ -316,36 +283,34 @@ int nvm_submit_io (struct nvm_io_cmd *io)
     ch = core.nvm_ch[aux_ch];
 #else
     /* For now all channels must be included in the global namespace */
-    for (i = 0; i < nvm_ch_count; i++) {
-        if (io->slba >= nvm_ch[i]->slba && io->slba <= nvm_ch[i]->elba) {
-            ch = nvm_ch[i];
+    for (i = 0; i < core.nvm_ch_count; i++) {
+        if (cmd->slba >= core.nvm_ch[i]->slba && cmd->slba <=
+                                                        core.nvm_ch[i]->elba) {
+            ch = core.nvm_ch[i];
             break;
         }
         syslog(LOG_INFO,"[nvm ERROR: IO failed, channel not found.]\n");
         req->status = NVME_INTERNAL_DEV_ERROR;
-        nvm_complete_io(io);
+        nvm_complete_to_host(cmd);
         return NVME_INTERNAL_DEV_ERROR;
     }
 #endif /* LIGHTNVM */
 
-    io->status.status = NVM_IO_PROCESS;
-    io->channel = ch;
-    retry = 16;
-    cmd_addr = (uint64_t) io;
+    cmd->status.status = NVM_IO_PROCESS;
+    cmd->channel = ch;
+    retry = NVM_QUEUE_RETRY;
 
-    /* TODO: Make the queues be native per-channel */
-    
-    qid = ch->ch_mmgr_id;//nvm_ftl_q_schedule(ch->ftl);
+    qid = nvm_ftl_q_schedule (ch->ftl, cmd);
     do {
-        ret = mq_send(ch->ftl->mq_id[qid], (char *) &cmd_addr,
-                                                         sizeof (uint64_t), 1);
-    	if (ret < 0)
+        ret = ox_mq_submit_req(ch->ftl->mq, qid, cmd);
+
+    	if (ret)
             retry--;
         else if (core.debug)
             printf(" CMD cid: %lu, type: 0x%x submitted to FTL. \n  Channel: "
-                    "%d, FTL queue %d\n", io->cid, io->cmdtype, ch->ch_id, qid);
+                  "%d, FTL queue %d\n", cmd->cid, cmd->cmdtype, ch->ch_id, qid);
 
-    } while (ret < 0 && retry);
+    } while (ret && retry);
 
   //  if (core.debug)
   //      usleep (150000);
@@ -375,7 +340,7 @@ int nvm_dma (void *ptr, uint64_t prp, ssize_t size, uint8_t direction)
     return 0;
 }
 
-int nvm_submit_mmgr_io (struct nvm_mmgr_io_cmd *cmd)
+int nvm_submit_mmgr (struct nvm_mmgr_io_cmd *cmd)
 {
     gettimeofday(&cmd->tstart,NULL);
     switch (cmd->nvm_io->cmdtype) {
@@ -624,16 +589,12 @@ static void nvm_unregister_mmgr (struct nvm_mmgr *mmgr)
 
 static void nvm_unregister_ftl (struct nvm_ftl *ftl)
 {
-    int i;
     if (LIST_EMPTY(&ftl_head))
         return;
 
-    for (i = 0; i < ftl->nq; i++) {
-        mq_close(ftl->mq_id[i]);
-        core.ftl_q_count--;
-    }
+    ox_mq_destroy(ftl->mq);
+    core.ftl_q_count -= ftl->nq;
 
-    pthread_mutex_destroy (&ftl->q_mutex);
     ftl->active = 0;
 
     ftl->ops->exit(ftl);

--- a/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.c
+++ b/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.c
@@ -74,10 +74,10 @@ static int lnvm_erase_blk (struct nvm_mmgr_io_cmd *cmd)
 static int lnvm_check_end_io (struct nvm_io_cmd *cmd)
 {
     if (cmd->status.pgs_p == cmd->status.total_pgs) {
-        
+
         pthread_mutex_lock(&endio_mutex);
         if ( lnvm_check_pgmap_complete(cmd->status.pg_map) ) { //IO not ended
-            
+
             cmd->status.ret_t++;
             if (cmd->status.ret_t <= FTL_LNVM_IO_RETRY) {
                 log_err ("[FTL WARNING: Cmd resubmitted due failed pages]\n");
@@ -88,24 +88,24 @@ static int lnvm_check_end_io (struct nvm_io_cmd *cmd)
                 cmd->status.nvme_status = NVME_DATA_TRAS_ERROR;
                 goto COMPLETE;
             }
-            
+
         } else {
             cmd->status.status = NVM_IO_SUCCESS;
             cmd->status.nvme_status = NVME_SUCCESS;
             goto COMPLETE;
-        }        
+        }
     }
     goto RETURN;
-    
+
 SUBMIT:
     pthread_mutex_unlock(&endio_mutex);
     lnvm_submit_io(cmd);
     goto RETURN;
-    
+
 COMPLETE:
     pthread_mutex_unlock(&endio_mutex);
     nvm_complete_ftl(cmd);
-    
+
 RETURN:
     return 0;
 }
@@ -120,7 +120,7 @@ static void lnvm_callback_io (struct nvm_mmgr_io_cmd *cmd)
         pthread_mutex_lock(&endio_mutex);
         cmd->nvm_io->status.pg_errors++;
     }
-    
+
     cmd->nvm_io->status.pgs_p++;
     pthread_mutex_unlock(&endio_mutex);
 
@@ -199,7 +199,7 @@ static int lnvm_check_io (struct nvm_io_cmd *cmd)
 
     if (cmd->cmdtype == MMGR_ERASE_BLK)
         return 0;
-    
+
     if (cmd->status.total_pgs * LNVM_SEC_PG > 64
                                                 || cmd->status.total_pgs == 0){
         cmd->status.status = NVM_IO_FAIL;
@@ -218,7 +218,7 @@ static int lnvm_submit_io (struct nvm_io_cmd *cmd)
     if (cmd->ppalist[0].g.pg > 64 && cmd->ppalist[0].g.pg < 68)
         return 0;
     */
-    
+
     int ret, i;
     ret = lnvm_check_io(cmd);
     if (ret) return ret;

--- a/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.c
+++ b/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.c
@@ -52,17 +52,17 @@ static int lnvm_check_pgmap_complete (uint8_t *pgmap) {
 
 static int lnvm_pg_read (struct nvm_mmgr_io_cmd *cmd)
 {
-    return nvm_submit_mmgr_io(cmd);
+    return nvm_submit_mmgr(cmd);
 }
 
 static int lnvm_pg_write (struct nvm_mmgr_io_cmd *cmd)
 {
-    return nvm_submit_mmgr_io(cmd);
+    return nvm_submit_mmgr(cmd);
 }
 
 static int lnvm_erase_blk (struct nvm_mmgr_io_cmd *cmd)
 {
-    return nvm_submit_mmgr_io(cmd);
+    return nvm_submit_mmgr(cmd);
 }
 
 /* If all pages were processed, it checks for errors. If all succeed, finish
@@ -78,16 +78,16 @@ static void lnvm_check_end_io (struct nvm_io_cmd *cmd)
             cmd->status.ret_t++;
             if (cmd->status.ret_t <= FTL_LNVM_IO_RETRY) {
                 log_err ("[FTL WARNING: Cmd resubmitted due failed pages]\n");
-                nvm_submit_io(cmd);
+                nvm_submit_ftl(cmd);
             } else {
                 cmd->status.status = NVM_IO_FAIL;
                 cmd->status.nvme_status = NVME_DATA_TRAS_ERROR;
-                nvm_complete_io(cmd);
+                nvm_complete_ftl(cmd);
             }
         } else {
             cmd->status.status = NVM_IO_SUCCESS;
             cmd->status.nvme_status = NVME_SUCCESS;
-            nvm_complete_io(cmd);
+            nvm_complete_ftl(cmd);
         }
         pthread_mutex_unlock(&endio_mutex);
     }
@@ -242,43 +242,43 @@ static int lnvm_init_channel (struct nvm_channel *ch)
     struct lnvm_channel *lch;
     uint32_t tblks;
     int rsv, l_addr, b_addr, pl_addr, trsv, n, pl, n_pl;
-    
+
     n_pl = ch->geometry->n_of_planes;
     ch->ftl_rsv = FTL_LNVM_RSV_BLK;
     trsv = ch->ftl_rsv * n_pl;
     ch->ftl_rsv_list = malloc (trsv * sizeof(struct nvm_ppa_addr));
-    
+
     if (!ch->ftl_rsv_list)
         return EMEM;
-    
+
     memset (ch->ftl_rsv_list, 0, trsv * sizeof(struct nvm_ppa_addr));
-    
+
     for (n = 0; n < ch->ftl_rsv; n++) {
         for (pl = 0; pl < n_pl; pl++) {
             ch->ftl_rsv_list[n_pl * n + pl].g.blk = n + ch->mmgr_rsv;
             ch->ftl_rsv_list[n_pl * n + pl].g.pl = pl;
         }
     }
-    
+
     lch = malloc (sizeof(struct lnvm_channel));
     if (!lch)
         return EMEM;
-    
+
     tblks = ch->geometry->blk_per_lun * ch->geometry->lun_per_ch * n_pl;
-    
+
     lch->ch = ch;
     lch->bbtbl = malloc (sizeof(uint8_t) * tblks);
     if (!lch->bbtbl)
         return EMEM;
-    
+
     memset (lch->bbtbl, 0, tblks);
-    
-    /* TODO: Verify if bbtbl exists in non-volatile storage             
+
+    /* TODO: Verify if bbtbl exists in non-volatile storage
              if not, create it and flush to nvm
              get bbtbl from non-volatile storage
-             flush bbtbl to nvm when get a set_bb_tbl with ppa sector > 0 
+             flush bbtbl to nvm when get a set_bb_tbl with ppa sector > 0
              move the loopings below to a bbtbl create fn */
-    
+
     /* Set FTL reserved bad blocks */
     for (rsv = 0; rsv < ch->ftl_rsv * n_pl; rsv++){
         l_addr = ch->ftl_rsv_list[rsv].g.lun * ch->geometry->blk_per_lun * n_pl;
@@ -320,18 +320,18 @@ static int lnvm_ftl_get_bbtbl (struct nvm_ppa_addr *ppa, uint8_t *bbtbl,
 
 static int lnvm_ftl_set_bbtbl (struct nvm_ppa_addr *ppa, uint8_t value)
 {
-    int l_addr, n_pl;    
+    int l_addr, n_pl;
     struct lnvm_channel *lch = lnvm_get_ch_instance(ppa->g.ch);
-    
+
     n_pl = lch->ch->geometry->n_of_planes;
-    
-    if ((ppa->g.blk * n_pl + ppa->g.pl) > 
+
+    if ((ppa->g.blk * n_pl + ppa->g.pl) >
                                    (lch->ch->geometry->blk_per_lun * n_pl - 1))
         return -1;
-    
-    l_addr = ppa->g.lun * lch->ch->geometry->blk_per_lun * n_pl;    
+
+    l_addr = ppa->g.lun * lch->ch->geometry->blk_per_lun * n_pl;
     lch->bbtbl[l_addr + (ppa->g.blk * n_pl + ppa->g.pl)] = value;
-    
+
     return 0;
 }
 
@@ -346,7 +346,7 @@ static void lnvm_exit (struct nvm_ftl *ftl)
         LIST_REMOVE (lch, entry);
         free (lch);
     } while (!LIST_EMPTY(&ch_head));
-    
+
     pthread_mutex_destroy (&endio_mutex);
 }
 

--- a/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.h
+++ b/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.h
@@ -15,7 +15,7 @@
 #include <sys/queue.h>
 #include "../../include/ssd.h"
 
-#define FTL_LNVM_IO_RETRY     16
+#define FTL_LNVM_IO_RETRY     0
 #define FTL_LNVM_RSV_BLK      1
 
 struct lnvm_page {

--- a/hw/block/ox-ctrl/include/nvme.h
+++ b/hw/block/ox-ctrl/include/nvme.h
@@ -852,10 +852,12 @@ typedef struct NvmeNamespace {
 } NvmeNamespace;
 
 typedef struct NvmeRequest {
+    uint8_t                  ext; /* allocated later due timeout request */
     TAILQ_ENTRY(NvmeRequest) entry;
+    LIST_ENTRY(NvmeRequest)  ext_req;
     struct NvmeSQ            *sq;
     struct NvmeNamespace     *ns;
-    struct NvmeCmd           *cmd;
+    struct NvmeCmd           cmd;
     NvmeCqe                  cqe;
     uint16_t                 status;
     uint64_t                 slba;
@@ -1056,6 +1058,7 @@ typedef struct NvmeCtrl {
     pthread_spinlock_t                          qs_req_spin;
     pthread_spinlock_t                          aer_req_spin;
     pthread_mutex_t                             req_mutex;
+    LIST_HEAD(ext_list, NvmeRequest)            ext_list;/*req allocated later*/
 
 #if LIGHTNVM
     LnvmCtrl     lightnvm_ctrl;
@@ -1065,7 +1068,7 @@ typedef struct NvmeCtrl {
 void nvme_exit(void);
 uint8_t nvme_write_to_host(void *, uint64_t, ssize_t);
 uint8_t nvme_read_from_host(void *, uint64_t, ssize_t);
-uint16_t nvme_init_cq (NvmeCQ *, NvmeCtrl *, uint64_t, uint16_t, uint16_t, 
+uint16_t nvme_init_cq (NvmeCQ *, NvmeCtrl *, uint64_t, uint16_t, uint16_t,
         uint16_t, uint16_t, int);
 uint16_t nvme_init_sq (NvmeSQ *, NvmeCtrl *, uint64_t, uint16_t, uint16_t,
         uint16_t, enum NvmeQFlags, int);

--- a/hw/block/ox-ctrl/include/ox-mq.h
+++ b/hw/block/ox-ctrl/include/ox-mq.h
@@ -39,6 +39,10 @@ struct ox_mq_queue {
     TAILQ_HEAD (cq_used_head, ox_mq_entry) cq_used;
     ox_mq_sq_fn                            *sq_fn;
     ox_mq_cq_fn                            *cq_fn;
+    pthread_mutex_t                        sq_cond_m;
+    pthread_mutex_t                        cq_cond_m;
+    pthread_cond_t                         sq_cond;
+    pthread_cond_t                         cq_cond;
     pthread_t                              sq_tid;
     pthread_t                              cq_tid;
     uint8_t                                running; /* if 0, kill threads */

--- a/hw/block/ox-ctrl/include/ssd.h
+++ b/hw/block/ox-ctrl/include/ssd.h
@@ -44,6 +44,7 @@
 #define NVM_QUEUE_RETRY         16
 #define NVM_QUEUE_RETRY_SLEEP   500
 #define NVM_FTL_QUEUE_SIZE      64
+#define NVM_FTL_QUEUE_TO        2000000
 
 #define NVM_SYNCIO_TO          10
 #define NVM_SYNCIO_FLAG_BUF    0x1

--- a/hw/block/ox-ctrl/include/ssd.h
+++ b/hw/block/ox-ctrl/include/ssd.h
@@ -44,7 +44,7 @@
 #define NVM_QUEUE_RETRY         16
 #define NVM_QUEUE_RETRY_SLEEP   500
 #define NVM_FTL_QUEUE_SIZE      64
-#define NVM_FTL_QUEUE_TO        2000000
+#define NVM_FTL_QUEUE_TO        100000
 
 #define NVM_SYNCIO_TO          10
 #define NVM_SYNCIO_FLAG_BUF    0x1
@@ -58,6 +58,7 @@
 
 #define AND64                  0xffffffffffffffff
 #define ZERO_32FLAG            0x00000000
+#define SEC64                  (1000000 & AND64)
 
 #define NVM_CH_IN_USE          0x3c
 

--- a/hw/block/ox-ctrl/include/ssd.h
+++ b/hw/block/ox-ctrl/include/ssd.h
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include "hw/block/ox-ctrl/include/uatomic.h"
+#include "hw/block/ox-ctrl/include/ox-mq.h"
 #include "qemu/osdep.h"
 #include "hw/block/block.h"
 #include "hw/pci/msix.h"
@@ -40,9 +41,9 @@
         OBJECT_CHECK(QemuOxCtrl, (obj), TYPE_OX)
 
 #define MAX_NAME_SIZE           31
-#define NVM_FTL_MQ             "/nvm_mq"
-#define NVM_FTL_MQ_MSGSIZE     8
-#define NVM_FTL_MQ_MAXMSG      64
+#define NVM_QUEUE_RETRY         16
+#define NVM_QUEUE_RETRY_SLEEP   500
+#define NVM_FTL_QUEUE_SIZE      64
 
 #define NVM_SYNCIO_TO          10
 #define NVM_SYNCIO_FLAG_BUF    0x1
@@ -128,6 +129,7 @@ struct nvm_io_cmd {
     struct nvm_io_status        status;
     struct nvm_mmgr_io_cmd      mmgr_io[64];
     void                        *req;
+    void                        *mq_req;
     uint64_t                    prp[64];
     uint64_t                    md_prp[64];
     uint32_t                    sec_sz;
@@ -291,10 +293,7 @@ struct nvm_ftl {
     uint32_t                cap; /* Capability bits */
     uint16_t                bbtbl_format;
     uint8_t                 nq; /* Number of queues/threads, up to 64 per FTL */
-    int16_t                 mq_id[64];
-    pthread_t               io_thread[64];
-    uint8_t                 last_q;
-    pthread_mutex_t         q_mutex;
+    struct ox_mq            *mq;
     uint8_t                 active;
     LIST_ENTRY(nvm_ftl)     entry;
 };
@@ -401,10 +400,10 @@ struct core_struct {
 int  nvm_register_mmgr(struct nvm_mmgr *);
 int  nvm_register_pcie_handler(struct nvm_pcie *);
 int  nvm_register_ftl (struct nvm_ftl *);
-int  nvm_submit_io (struct nvm_io_cmd *);
-int  nvm_submit_mmgr_io (struct nvm_mmgr_io_cmd *);
+int  nvm_submit_ftl (struct nvm_io_cmd *);
+int  nvm_submit_mmgr (struct nvm_mmgr_io_cmd *);
+void nvm_complete_ftl (struct nvm_io_cmd *);
 void nvm_callback (struct nvm_mmgr_io_cmd *);
-void nvm_complete_io (struct nvm_io_cmd *);
 int  nvm_dma (void *, uint64_t, ssize_t, uint8_t);
 int  nvm_memcheck (void *);
 int  nvm_ftl_cap_exec (uint8_t, void **, int);

--- a/hw/block/ox-ctrl/lightnvm.c
+++ b/hw/block/ox-ctrl/lightnvm.c
@@ -107,24 +107,24 @@ uint16_t lnvm_set_bb_tbl(NvmeCtrl *n, NvmeCmd *nvmecmd, NvmeRequest *req)
     uint64_t spba = cmd->spba;
     uint16_t nlb = cmd->nlb + 1;
     uint8_t value = cmd->value;
-    
+
     psl = malloc (sizeof(struct nvm_ppa_addr) * nlb);
     if (!psl)
         return NVME_INTERNAL_DEV_ERROR;
-    
+
     if (nlb > 1) {
         nvme_read_from_host((void *)psl, spba, nlb * sizeof(uint64_t));
     } else {
         psl[0].ppa = spba;
     }
-    
+
     for(i = 0; i < nlb; i++) {
         /* set single block to FTL */
         psl[i].g.sec = 0;
         arg[0] = &psl[i].ppa;
         arg[1] = &value;
         arg[2] = &bbtbl_format;
-        
+
         ret = nvm_ftl_cap_exec(FTL_CAP_SET_BBTBL, arg, 3);
         if (ret)
             return NVME_INVALID_FIELD;
@@ -248,7 +248,7 @@ uint16_t lnvm_erase_sync(NvmeCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
         lnvm_debug_print_io (req->nvm_io.ppalist, req->nvm_io.prp,
                                                 req->nvm_io.md_prp, nlb, 0, 0);
 
-    return nvm_submit_io(&req->nvm_io);
+    return nvm_submit_ftl(&req->nvm_io);
 }
 
 static inline uint64_t nvme_gen_to_dev_addr(LnvmCtrl *ln,struct nvm_ppa_addr *r)
@@ -366,7 +366,7 @@ uint16_t lnvm_rw(NvmeCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd, NvmeRequest *req)
         lnvm_debug_print_io (req->nvm_io.ppalist, req->nvm_io.prp,
                                 req->nvm_io.md_prp, nlb, data_size, meta_size);
 
-    return nvm_submit_io(&req->nvm_io);
+    return nvm_submit_ftl(&req->nvm_io);
 }
 
 static int lightnvm_flush_tbls(NvmeCtrl *n)

--- a/hw/block/ox-ctrl/mmgr/volt/volt.h
+++ b/hw/block/ox-ctrl/mmgr/volt/volt.h
@@ -31,7 +31,8 @@
 #define VOLT_WRITE_TIME     200
 #define VOLT_ERASE_TIME     1200
 
-#define VOLT_QUEUE_SIZE     16
+#define VOLT_QUEUE_SIZE     128
+#define VOLT_QUEUE_TO       48000
 
 typedef struct VoltStatus {
     uint8_t     ready; /* 0x00-busy, 0x01-ready to use */
@@ -65,6 +66,7 @@ typedef struct VoltCtrl {
     VoltLun         *luns;
     VoltCh          *channels;
     struct ox_mq    *mq;
+    uint8_t         *edma; /* emergency DMA buffer for timeout requests */
 } VoltCtrl;
 
 struct volt_dma {

--- a/hw/block/ox-ctrl/nvme_cmd.c
+++ b/hw/block/ox-ctrl/nvme_cmd.c
@@ -735,5 +735,5 @@ uint16_t nvme_rw (NvmeCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
         req->nvm_io.mmgr_io[i].pg_sz = NVME_KERNEL_PG_SIZE;
     }
 
-    return nvm_submit_io(&req->nvm_io);
+    return nvm_submit_ftl(&req->nvm_io);
 }

--- a/hw/block/ox-ctrl/ox-mq.c
+++ b/hw/block/ox-ctrl/ox-mq.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <string.h>
+#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/queue.h>
@@ -22,6 +23,22 @@ void ox_mq_show_stats (struct ox_mq *mq)
                 u_atomic_read(&q->stats.cq_free),
                 u_atomic_read(&q->stats.cq_used));
     }
+    log_info ("EXT %d, TO: %d, TO_BACK: %d\n",
+                u_atomic_read(&mq->stats.ext_list),
+                u_atomic_read(&mq->stats.timeout),
+                u_atomic_read(&mq->stats.to_back));
+}
+
+static void ox_mq_init_stats (struct ox_mq_stats *stats)
+{
+    stats->cq_free.counter = U_ATOMIC_INIT_RUNTIME(0);
+    stats->cq_used.counter = U_ATOMIC_INIT_RUNTIME(0);
+    stats->sq_free.counter = U_ATOMIC_INIT_RUNTIME(0);
+    stats->sq_used.counter = U_ATOMIC_INIT_RUNTIME(0);
+    stats->sq_wait.counter = U_ATOMIC_INIT_RUNTIME(0);
+    stats->ext_list.counter = U_ATOMIC_INIT_RUNTIME(0);
+    stats->timeout.counter = U_ATOMIC_INIT_RUNTIME(0);
+    stats->to_back.counter = U_ATOMIC_INIT_RUNTIME(0);
 }
 
 static void ox_mq_destroy_sq (struct ox_mq_queue *q)
@@ -104,17 +121,15 @@ static int ox_mq_init_queue (struct ox_mq_queue *q, uint32_t size,
     if (ox_mq_init_cq (q, size))
         goto CLEAN_SQ;
 
-    q->stats.cq_free.counter = U_ATOMIC_INIT_RUNTIME(0);
-    q->stats.cq_used.counter = U_ATOMIC_INIT_RUNTIME(0);
-    q->stats.sq_free.counter = U_ATOMIC_INIT_RUNTIME(0);
-    q->stats.sq_used.counter = U_ATOMIC_INIT_RUNTIME(0);
-    q->stats.sq_wait.counter = U_ATOMIC_INIT_RUNTIME(0);
+    ox_mq_init_stats(&q->stats);
 
     for (i = 0; i < size; i++) {
         TAILQ_INSERT_TAIL (&q->sq_free, &q->sq_entries[i], entry);
         u_atomic_inc(&q->stats.sq_free);
         TAILQ_INSERT_TAIL (&q->cq_free, &q->cq_entries[i], entry);
         u_atomic_inc(&q->stats.cq_free);
+        pthread_mutex_init (&q->sq_entries[i].entry_mutex, NULL);
+        pthread_mutex_init (&q->cq_entries[i].entry_mutex, NULL);
     }
 
     q->running = 1; /* ready */
@@ -127,14 +142,54 @@ CLEAN_SQ:
     return -1;
 }
 
+inline static void ox_mq_reset_entry (struct ox_mq_entry *entry)
+{
+    entry->status = OX_MQ_FREE;
+    entry->opaque = NULL;
+    entry->qid = 0;
+    memset (&entry->wtime, 0, sizeof (struct timeval));
+}
+
+static struct ox_mq_entry *ox_mq_create_ext_entry (struct ox_mq *mq)
+{
+    struct ox_mq_entry *new_entry;
+
+    new_entry = malloc (sizeof (struct ox_mq_entry));
+    if (!new_entry)
+        return NULL;
+
+    new_entry->is_ext = 0x1;
+    pthread_mutex_init (&new_entry->entry_mutex, NULL);
+    ox_mq_reset_entry (new_entry);
+
+    LIST_INSERT_HEAD (&mq->ext_list, new_entry, ext_entry);
+    u_atomic_inc (&mq->stats.ext_list);
+
+    return new_entry;
+}
+
+static void ox_mq_free_entry (struct ox_mq *mq, struct ox_mq_entry *entry)
+{
+    if (entry->is_ext) {
+        LIST_REMOVE (entry, ext_entry);
+        pthread_mutex_destroy (&entry->entry_mutex);
+        free (entry);
+        u_atomic_dec (&mq->stats.ext_list);
+    }
+}
+
 static void ox_mq_free_queues (struct ox_mq *mq, uint32_t n_queues)
 {
-    int i;
+    int i, j;
     struct ox_mq_queue *q;
 
     for (i = 0; i < n_queues; i++) {
         q = &mq->queues[i];
         q->running = 0; /* stop threads */
+        for (j = 0; j < mq->config->q_size; j++) {
+            pthread_mutex_destroy (&q->sq_entries[j].entry_mutex);
+            pthread_mutex_destroy (&q->cq_entries[j].entry_mutex);
+        }
         ox_mq_destroy_sq (q);
         free (q->sq_entries);
         ox_mq_destroy_cq (q);
@@ -149,9 +204,16 @@ static void ox_mq_free_queues (struct ox_mq *mq, uint32_t n_queues)
         u_atomic_inc((stat));                                       \
 } while (/*CONSTCOND*/0)
 
+#define OX_MQ_DEQUEUE_H(head, elm, mutex, stats) do {               \
+        pthread_mutex_lock((mutex));                                \
+        (elm) = TAILQ_FIRST((head));                                \
+        TAILQ_REMOVE ((head), (elm), entry);                        \
+        pthread_mutex_unlock ((mutex));                             \
+        u_atomic_dec((stats));                                      \
+} while (/*CONSTCOND*/0)
+
 #define OX_MQ_DEQUEUE(head, elm, mutex, stats) do {                 \
         pthread_mutex_lock((mutex));                                \
-        req = TAILQ_FIRST((head));                                  \
         TAILQ_REMOVE ((head), (elm), entry);                        \
         pthread_mutex_unlock ((mutex));                             \
         u_atomic_dec((stats));                                      \
@@ -170,7 +232,11 @@ static void *ox_mq_sq_thread (void *arg)
 
         pthread_mutex_unlock(&q->sq_cond_m);
 
-        OX_MQ_DEQUEUE (&q->sq_used, req, &q->sq_used_mutex, &q->stats.sq_used);
+        OX_MQ_DEQUEUE_H(&q->sq_used, req, &q->sq_used_mutex, &q->stats.sq_used);
+
+        gettimeofday(&req->wtime, NULL);
+
+        req->status = OX_MQ_WAITING;
         OX_MQ_ENQUEUE (&q->sq_wait, req, &q->sq_wait_mutex, &q->stats.sq_wait);
 
         q->sq_fn (req);
@@ -193,9 +259,9 @@ static void *ox_mq_cq_thread (void *arg)
 
         pthread_mutex_unlock(&q->cq_cond_m);
 
-        OX_MQ_DEQUEUE (&q->cq_used, req, &q->cq_used_mutex, &q->stats.cq_used);
+        OX_MQ_DEQUEUE_H(&q->cq_used, req, &q->cq_used_mutex, &q->stats.cq_used);
         opaque = req->opaque;
-        memset (req, 0, sizeof (struct ox_mq_entry));
+        ox_mq_reset_entry (req);
         OX_MQ_ENQUEUE (&q->cq_free, req, &q->cq_free_mutex, &q->stats.cq_free);
 
         q->cq_fn (opaque);
@@ -226,7 +292,7 @@ int ox_mq_submit_req (struct ox_mq *mq, uint32_t qid, void *opaque)
 
     q = &mq->queues[qid];
 
-    /* TODO: retry user defined times if queue is full */
+    /* If queue is full, the request is rejected */
     pthread_mutex_lock (&q->sq_free_mutex);
     if (TAILQ_EMPTY (&q->sq_free)) {
         pthread_mutex_unlock (&q->sq_free_mutex);
@@ -245,9 +311,11 @@ int ox_mq_submit_req (struct ox_mq *mq, uint32_t qid, void *opaque)
     if (TAILQ_EMPTY (&q->sq_used))
         wake++;
 
+    req->status = OX_MQ_QUEUED;
     TAILQ_INSERT_TAIL (&q->sq_used, req, entry);
     u_atomic_inc(&q->stats.sq_used);
 
+    /* Wake consumer thread if queue was empty */
     if (wake) {
         pthread_mutex_lock (&q->sq_cond_m);
         pthread_cond_signal(&q->sq_cond);
@@ -264,10 +332,24 @@ int ox_mq_complete_req (struct ox_mq *mq, struct ox_mq_entry *req_sq)
     struct ox_mq_entry *req_cq;
     uint8_t wake = 0;
 
-    if (!req_sq || !req_sq->opaque)
+    pthread_mutex_lock (&req_sq->entry_mutex);
+    /* Timeout requests are OX_MQ_TIMEOUT_BACK after the first completion try */
+    if (!req_sq || !req_sq->opaque || req_sq->status == OX_MQ_TIMEOUT_BACK) {
+        pthread_mutex_unlock (&req_sq->entry_mutex);
         return -1;
+    }
+
+    /* Check if request is a TIMEOUT_COMPLETED but not TIMEOUT_BACK */
+    if (req_sq->status == OX_MQ_TIMEOUT_COMPLETED) {
+        ox_mq_free_entry(mq, req_sq);
+        u_atomic_inc(&mq->stats.to_back);
+        pthread_mutex_unlock (&req_sq->entry_mutex);
+        req_sq->status = OX_MQ_TIMEOUT_BACK;
+        return -1;
+    }
 
     q = &mq->queues[req_sq->qid];
+    pthread_mutex_unlock (&req_sq->entry_mutex);
 
     /* TODO: retry user defined times if queue is full */
     pthread_mutex_lock (&q->cq_free_mutex);
@@ -282,24 +364,27 @@ int ox_mq_complete_req (struct ox_mq *mq, struct ox_mq_entry *req_sq)
     pthread_mutex_unlock (&q->cq_free_mutex);
     u_atomic_dec(&q->stats.cq_free);
 
+    pthread_mutex_lock (&req_sq->entry_mutex);
     req_cq->opaque = req_sq->opaque;
     req_cq->qid = req_sq->qid;
 
-    pthread_mutex_lock (&q->sq_wait_mutex);
-    TAILQ_REMOVE (&q->sq_wait, req_sq, entry);
-    pthread_mutex_unlock (&q->sq_wait_mutex);
-    u_atomic_dec(&q->stats.sq_wait);
+    if (req_sq->status == OX_MQ_WAITING) {
+        OX_MQ_DEQUEUE (&q->sq_wait,req_sq,&q->sq_wait_mutex,&q->stats.sq_wait);
 
-    memset (req_sq, 0, sizeof (struct ox_mq_entry));
-    OX_MQ_ENQUEUE (&q->sq_free, req_sq, &q->sq_free_mutex, &q->stats.sq_free);
+        ox_mq_reset_entry (req_sq);
+        OX_MQ_ENQUEUE (&q->sq_free,req_sq,&q->sq_free_mutex,&q->stats.sq_free);
+    }
+    pthread_mutex_unlock (&req_sq->entry_mutex); /**/
 
     pthread_mutex_lock (&q->cq_used_mutex);
     if (TAILQ_EMPTY (&q->cq_used))
         wake++;
 
+    req_cq->status = OX_MQ_QUEUED;
     TAILQ_INSERT_TAIL (&q->cq_used, req_cq, entry);
     u_atomic_inc(&q->stats.cq_used);
 
+    /* Wake consumer thread if queue was empty */
     if (wake) {
         pthread_mutex_lock (&q->cq_cond_m);
         pthread_cond_signal(&q->cq_cond);
@@ -310,32 +395,134 @@ int ox_mq_complete_req (struct ox_mq *mq, struct ox_mq_entry *req_sq)
     return 0;
 }
 
+static int ox_mq_check_entry_to (struct ox_mq *mq, struct ox_mq_entry *entry)
+{
+    struct timeval cur;
+    uint64_t usec_e, usec_s, tot;
+
+    gettimeofday(&cur, NULL);
+
+    usec_e = cur.tv_sec * SEC64;
+    usec_e += cur.tv_usec;
+    usec_s = entry->wtime.tv_sec * SEC64;
+    usec_s += entry->wtime.tv_usec;
+
+    tot = usec_e - usec_s;
+
+    return (tot >= mq->config->to_usec);
+}
+
+static int ox_mq_process_to_entry (struct ox_mq *mq, struct ox_mq_queue *q,
+                                                      struct ox_mq_entry *req) {
+    struct ox_mq_entry *new_req;
+
+    TAILQ_REMOVE (&q->sq_wait, req, entry);
+    u_atomic_dec(&q->stats.sq_wait);
+
+    req->status = OX_MQ_TIMEOUT;
+
+    new_req = ox_mq_create_ext_entry(mq);
+    if (!new_req)
+        goto ERR;
+
+    OX_MQ_ENQUEUE(&q->sq_free, new_req, &q->sq_free_mutex, &q->stats.sq_free);
+
+    return 0;
+
+ERR:
+    log_err (" [ox-mq: WARNING: timeout entry is out of list, not possible "
+                        "to allocate new entry. Queue size is now smaller.\n");
+    return -1;
+}
+
+static void ox_mq_check_queue_to (struct ox_mq *mq, struct ox_mq_queue *q)
+{
+    struct ox_mq_entry *req;
+    struct ox_mq_entry **to_list;
+    void **to_opaque;
+    int to_count, i;
+
+    to_count = 0;
+    to_list = NULL;
+    pthread_mutex_lock (&q->sq_wait_mutex);
+
+    /* Check and process the list of timeout requests */
+    TAILQ_FOREACH (req, &q->sq_wait, entry) {
+        if (ox_mq_check_entry_to(mq, req)) {
+
+            ox_mq_process_to_entry (mq, q, req);
+            if (to_count)
+                to_list = realloc (to_list, sizeof (void *) * to_count + 1);
+            else
+                to_list = malloc (sizeof (void *));
+
+            to_list[to_count] = req;
+            u_atomic_inc(&mq->stats.timeout);
+            to_count++;
+
+        }
+    }
+
+    pthread_mutex_unlock (&q->sq_wait_mutex);
+
+    if (to_count)
+        to_opaque = malloc (sizeof (void *) * to_count);
+
+    for (i = 0; i < to_count; i++)
+        to_opaque[i] = to_list[i]->opaque;
+
+    /* Call user defined timeout function */
+    if (to_count)
+        mq->config->to_fn (to_opaque, to_count);
+
+    /* Complete the list of timeout requests, if flag enabled */
+    i = to_count;
+    while (i) {
+        i--;
+        if (mq->config->to_fn && (mq->config->flags & OX_MQ_TO_COMPLETE))
+            if (ox_mq_complete_req(mq, to_list[i]))
+                log_err (" [ox-mq: WARNING: Not possible to post completion "
+                                                      "for a timeout request");
+        to_list[i]->status = OX_MQ_TIMEOUT_COMPLETED;
+    }
+
+    if (to_count) {
+        free (to_opaque);
+        free (to_list);
+    }
+}
+
+/*
+ * This thread checks all sq_wait queues for timeout requests.
+ *
+ * If a timeout entry id found, the follow steps are performed:
+ *  - Remove the entry from sq_wait;
+ *  - Set timeout entry status to OX_MQ_TIMEOUT;
+ *  - Allocate a new entry;
+ *  - Insert the new entry to the sq_free;
+ *  - Insert the new entry to mq->ext_entries for exit free process;
+ *
+ * After all entries are processed:
+ *  - Call the user defined timeout function and pass the list of TO entries;
+ *    - In this function, the user should set the opaque structures as failed
+ *  - If the flag is enabled, submit all the entries for completion;
+ *  - Set timeout entries status to OX_MQ_TIMEOUT_COMPLETED;
+ *
+ * If the entry is called for completion later:
+ *  - Check is the entry is part of the ext_entries, if yes, free memory;
+ *    - Set the entry as OX_MQ_TIMEOUT_BACK (to avoid double free)
+ */
 static void *ox_mq_to_thread (void *arg)
 {
     struct ox_mq *mq = (struct ox_mq *) arg;
     int exit, i;
-    
+
     do {
         usleep (mq->config->to_usec);
-        // add btree library
-        // create btree timeout 
-        // create btree for ext_entries
-        
-        // verify all wait queues
-        // enqueue timeout entry to to_btree
-        // allocate new entry and enqueue pointer to ext_entries btree
-        // also enqueue new entry to sq_free list        
-        // complete request if flag is active
-        // call user to_fn
-        
-        // in the completion fn, check if to_btree contains the pointer,
-        // if yes, remove from to_btree and free if ext_entries contains the ptr
-        //   remove from ext_entries if freed
-        
-        // create status for timeout entries, timeout completion hits, btrees 
-        
-        // make volt + core timeout functions
-        
+
+        for (i = 0; i < mq->config->n_queues; i++)
+            ox_mq_check_queue_to(mq, &mq->queues[i]);
+
         exit = mq->config->n_queues;
         for (i = 0; i < mq->config->n_queues; i++) {
             if (!mq->queues[i].running)
@@ -344,8 +531,18 @@ static void *ox_mq_to_thread (void *arg)
         if (!exit)
             break;
     } while (1);
-    
+
     return NULL;
+}
+
+static int ox_mq_start_to (struct ox_mq *mq)
+{
+    LIST_INIT (&mq->ext_list);
+
+    if (pthread_create(&mq->to_tid, NULL, ox_mq_to_thread, mq))
+        return -1;
+
+    return 0;
 }
 
 struct ox_mq *ox_mq_init (struct ox_mq_config *config)
@@ -362,44 +559,58 @@ struct ox_mq *ox_mq_init (struct ox_mq_config *config)
 
     mq->queues = malloc (sizeof (struct ox_mq_queue) * config->n_queues);
     if (!mq->queues)
-        goto CLEAN_MQ;
+        goto FREE_MQ;
     memset (mq->queues, 0, sizeof (struct ox_mq_queue) * config->n_queues);
 
+    ox_mq_init_stats(&mq->stats);
+
     for (i = 0; i < config->n_queues; i++) {
-        if (ox_mq_init_queue (&mq->queues[i], config->q_size, 
+        if (ox_mq_init_queue (&mq->queues[i], config->q_size,
                                                config->sq_fn, config->cq_fn)) {
             ox_mq_free_queues (mq, i);
-            goto CLEAN_Q;
+            goto FREE_Q;
         }
 
         if (ox_mq_start_thread (&mq->queues[i])) {
             ox_mq_free_queues (mq, i + 1);
-            goto CLEAN_Q;
+            goto FREE_Q;
         }
     }
-    
-    if (pthread_create(&mq->to_tid, NULL, ox_mq_to_thread, mq))
-        goto CLEAN_ALL;
-    
+
     mq->config = config;
 
-    log_info (" [ox-mq: Multi queue started (nq: %d, qs: %d)\n", 
+    if (mq->config->to_usec && ox_mq_start_to(mq))
+        goto FREE_ALL;
+
+    log_info (" [ox-mq: Multi queue started (nq: %d, qs: %d)\n",
                                              config->n_queues, config->q_size);
     return mq;
 
-CLEAN_ALL:
+FREE_ALL:
     ox_mq_free_queues (mq, config->n_queues);
-CLEAN_Q:
+FREE_Q:
     free (mq->queues);
-CLEAN_MQ:
+FREE_MQ:
     free (mq);
     return NULL;
 }
 
+static void ox_mq_free_ext_list (struct ox_mq *mq)
+{
+    struct ox_mq_entry *entry;
+
+    while (!LIST_EMPTY(&mq->ext_list)) {
+        entry = LIST_FIRST (&mq->ext_list);
+        if (entry)
+            ox_mq_free_entry(mq, entry);
+    }
+}
+
 void ox_mq_destroy (struct ox_mq *mq)
-{    
+{
     ox_mq_free_queues(mq, mq->config->n_queues);
     pthread_join (mq->to_tid, NULL);
+    ox_mq_free_ext_list (mq);
     free (mq->queues);
     free (mq);
 }


### PR DESCRIPTION
Timeout support in the ox-mq is composed by a thread that checks for timeout requests in the queues.
The follow steps are performed:

  If a timeout entry id found, the follow steps are performed:

     - Check all waiting request lists, if some timeout request is found, we perform:
     - Remove the entry from sq_wait;
     - Set timeout entry status to OX_MQ_TIMEOUT;
     - Allocate a new entry;
     - Insert the new entry to the sq_free;
     - Insert the new entry to mq->ext_entries for exit free process; 

     - After all entries are processed:
        - Call the user defined timeout function and pass the list of TO entries;
        - In this function, the user should set the opaque structures as failed
        - If the flag is enabled, submit all the entries for completion;
        - Set timeout entries status to OX_MQ_TIMEOUT_COMPLETED; 

     - If the entry is called for completion later:
        - Check is the entry is part of the ext_entries, if yes, free memory;
        - Set the entry as OX_MQ_TIMEOUT_BACK (to avoid double free)

When an entry is timeout, it avoids reusing the same memory slot for other requests, instead, a 
new entry is created and enqueued as free. The old entry stays in a special location to be freed 
later or if the request completion is called later. 

In case of timeout we also redirect the DMA to an emergency memory location, than we can free
the DMA slot for new requests.