### PR TITLE
Added ox commands to the hmp

### DIFF
--- a/hmp-commands-info.hx
+++ b/hmp-commands-info.hx
@@ -811,6 +811,18 @@ ETEXI
     },
 
 STEXI
+@item ox-info-debug
+Display the status of debugging in ox
+ETEXI
+
+    {
+        .name       = "ox_debug",
+       .args_type  = "",
+       .params     = "",
+       .help       = "Show the status of debugging in ox",
+       .mhandler.cmd = hmp_info_ox_debug,
+   },
+STEXI
 @item info hotpluggable-cpus
 @findex hotpluggable-cpus
 Show information about hotpluggable CPUs

--- a/hmp-commands.hx
+++ b/hmp-commands.hx
@@ -1744,6 +1744,18 @@ ETEXI
     },
 
 STEXI
+@item ox-debug
+Prints Enables or disables debugging of ox (on/off)
+ETEXI
+
+    {
+        .name       = "ox_debug",
+       .args_type  = "on_off:s",
+       .params     = "on_off",
+       .help       = "Enables or disables debugging of ox (on/off)",
+       .mhandler.cmd = hmp_ox_debug,
+   },
+STEXI
 @item qom-set @var{path} @var{property} @var{value}
 Set QOM property @var{property} of object at location @var{path} to value @var{value}
 ETEXI

--- a/hmp.c
+++ b/hmp.c
@@ -37,6 +37,8 @@
 #include "qemu/cutils.h"
 #include "qemu/error-report.h"
 
+#include "hw/block/ox-ctrl/include/ssd.h"
+
 #ifdef CONFIG_SPICE
 #include <spice/enums.h>
 #endif
@@ -2445,4 +2447,24 @@ void hmp_hotpluggable_cpus(Monitor *mon, const QDict *qdict)
     }
 
     qapi_free_HotpluggableCPUList(saved);
+}
+
+extern struct core_struct core;
+void hmp_ox_debug(Monitor *mon, const QDict *qdict)
+{
+        const char *name = qdict_get_str(qdict, "on_off");
+        if (!strcmp(name, "on") || !strcmp(name, "off")) {
+                core.debug = strcmp(name, "on") ? 0 : 1;
+                monitor_printf(mon, "OX: debugging %s\n",
+                               core.debug ? "enabled" : "disabled");
+        }
+        else {
+                monitor_printf(mon, "OX: Only accepts \"on\" or \"off\". Found: %s\n",
+                               qdict_get_str(qdict, "on_off"));
+        }
+}
+
+void hmp_info_ox_debug(Monitor *mon, const QDict *qdict)
+{
+        monitor_printf(mon, "OX: debugging is %s\n", core.debug ? "on" : "off");
 }

--- a/hmp.h
+++ b/hmp.h
@@ -135,4 +135,7 @@ void hmp_rocker_of_dpa_groups(Monitor *mon, const QDict *qdict);
 void hmp_info_dump(Monitor *mon, const QDict *qdict);
 void hmp_hotpluggable_cpus(Monitor *mon, const QDict *qdict);
 
+void hmp_ox_debug(Monitor *mon, const QDict *qdict);
+void hmp_info_ox_debug(Monitor *mon, const QDict *qdict);
+
 #endif

--- a/hw/block/ox-ctrl/cmd_args.c
+++ b/hw/block/ox-ctrl/cmd_args.c
@@ -175,7 +175,6 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 
     switch(key)
     {
-        printf("%s\n", arg);
         case ARGP_KEY_ARG:
             if (strcmp(arg, "start") == 0)
                 args->cmdtype = CMDARG_START;

--- a/qga/commands-posix.c
+++ b/qga/commands-posix.c
@@ -40,6 +40,7 @@ extern char **environ;
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <net/if.h>
+#include <sys/sysmacros.h>
 
 #ifdef FIFREEZE
 #define CONFIG_FSFREEZE


### PR DESCRIPTION
This pull request adds support for enabling or disabling the debugging output in qemu-ox from the hmp.
Example run:
(qemu) help ox_debug 
ox_debug on_off -- Enables or disables debugging of ox (on/off)
(qemu) ox_debug off
OX: debugging disabled
(qemu) help info ox_debug 
info ox_debug  -- Show the status of debugging in ox
(qemu) info ox_debug 
OX: debugging is off
(qemu) 