### PR TITLE
fix lnvm read sec bug, fix volt_get_next_prp

### DIFF
--- a/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.c
+++ b/hw/block/ox-ctrl/ftl/lnvm/ftl_lnvm.c
@@ -171,6 +171,7 @@ static int lnvm_check_pg_io (struct nvm_io_cmd *cmd, uint8_t index)
     mio->sec_sz = cmd->sec_sz;
     mio->md_sz = LNVM_SEC_OOBSZ * LNVM_SEC_PG;
 
+    memset(mio->prp, 0x0, sizeof(uint64_t) * LNVM_SEC_PG);
     for (c = 0; c < mio->n_sectors; c++)
         mio->prp[cmd->ppalist[mio->sec_offset + c].g.sec] =
                                                 cmd->prp[mio->sec_offset + c];

--- a/hw/block/ox-ctrl/mmgr/volt/volt.c
+++ b/hw/block/ox-ctrl/mmgr/volt/volt.c
@@ -58,9 +58,11 @@ static uint32_t volt_get_next_prp(struct volt_dma *dma, uint32_t ch){
             usleep(1);
             continue;
         }
-        pthread_mutex_unlock(&prpmap_mutex[ch]);
 
-        volt_set_prp_map(next, ch, 0x1);
+        /* set prp_map instantly */
+        prp_map[ch] |= 1 << (next - 1);
+
+        pthread_mutex_unlock(&prpmap_mutex[ch]);
 
         dma->prp_index = next;
 


### PR DESCRIPTION
In function lnvm_check_pg_io:
mio->prp should be set zero first, to eliminate obsolete prps.

In function volt_get_next_prp:
prp_map needs to be set instantly. Otherwise, others may not know the result, if you fail to lock the next mutex in time.